### PR TITLE
WIP: Voice UI

### DIFF
--- a/src/controllers/voice.js
+++ b/src/controllers/voice.js
@@ -1,0 +1,4 @@
+Controllers.renderVoice = (req, res) => {
+    res.send('Hello World');
+    console.log("i am in voice js rn");
+};

--- a/src/controllers/voice.js
+++ b/src/controllers/voice.js
@@ -1,4 +1,0 @@
-Controllers.renderVoice = (req, res) => {
-    res.send('Hello World');
-    console.log("i am in voice js rn");
-};

--- a/vendor/nodebb-theme-harmony-2.1.15/lib/controllers.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/lib/controllers.js
@@ -11,6 +11,14 @@ Controllers.renderAdminPage = (req, res) => {
 	});
 };
 
+// voice path
+Controllers.renderVoice = async (req, res) => {
+	res.render('voice', {
+		title: 'Voice',
+		breadcrumbs: helpers.buildBreadcrumbs([{ text: 'Voice' }]),
+	});
+};
+
 Controllers.renderThemeSettings = async (req, res, next) => {
 	const userData = await accountHelpers.getUserDataByUserSlug(req.params.userslug, req.uid, req.query);
 	if (!userData) {

--- a/vendor/nodebb-theme-harmony-2.1.15/library.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/library.js
@@ -48,7 +48,7 @@ async function buildSkins() {
 		const plugins = require.main.require('./src/plugins');
 		await plugins.prepareForBuild(['client side styles']);
 		for (const skin of meta.css.supportedSkins) {
-			// eslint-disable-next-line no-await-in-loop
+			 
 			await meta.css.buildBundle(`client-${skin}`, true);
 		}
 		require.main.require('./src/meta/minifier').killAll();

--- a/vendor/nodebb-theme-harmony-2.1.15/library.js
+++ b/vendor/nodebb-theme-harmony-2.1.15/library.js
@@ -28,6 +28,9 @@ library.init = async function (params) {
 
 	routeHelpers.setupAdminPageRoute(router, '/admin/plugins/harmony', [], controllers.renderAdminPage);
 
+	//setting up voice
+	routeHelpers.setupPageRoute(router, '/voice', middleware, [], controllers.renderVoice);
+
 	routeHelpers.setupPageRoute(router, '/user/:userslug/theme', [
 		middleware.exposeUid,
 		middleware.ensureLoggedIn,
@@ -86,7 +89,7 @@ library.defineWidgetAreas = async function (areas) {
 	const templates = [
 		'categories.tpl', 'category.tpl', 'topic.tpl', 'users.tpl',
 		'unread.tpl', 'recent.tpl', 'popular.tpl', 'top.tpl', 'tags.tpl', 'tag.tpl',
-		'login.tpl', 'register.tpl', 'world.tpl',
+		'login.tpl', 'register.tpl', 'world.tpl', 'voice.tpl',
 	];
 	function capitalizeFirst(str) {
 		return str.charAt(0).toUpperCase() + str.slice(1);

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/sidebar-left.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/sidebar-left.tpl
@@ -23,6 +23,18 @@
 		</li>
 		{{{ end }}}
 		{{{ end }}}
+
+		
+		<li class="nav-item mx-2" title="Voice">
+			<a class="nav-link navigation-link d-flex gap-2 justify-content-between align-items-center" href="/voice">
+				<span class="d-flex gap-2 align-items-center text-nowrap truncate-open">
+					<span class="position-relative">
+						<i class="fa fa-fw fa-headset"></i>
+					</span>
+					<span class="nav-text small visible-open fw-semibold text-truncate">Voice</span>
+				</span>
+			</a>
+		</li>
 	</ul>
 	<div class="sidebar-toggle-container align-self-start">
 		{{{ if !config.disableCustomUserSkins }}}

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/partials/voice_student.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/partials/voice_student.tpl
@@ -1,0 +1,30 @@
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-6 text-center">
+
+      <h2 class="mb-3">Voice Channel - {role}</h2>
+
+      <p class="mb-5 fs-5">{queueCount} students ahead of you</p>
+
+      <form method="post" action="{config.relative_path}/voice/submit">
+
+        <div class="mb-4">
+          <label for="voice-question" class="visually-hidden">Your question</label>
+          <textarea id="voice-question"
+                    name="question"
+                    class="form-control form-control-lg text-center py-4"
+                    rows="3"
+                    placeholder="Please enter your question"></textarea>
+        </div>
+
+        <div>
+          <button type="submit" class="btn btn-secondary btn-lg px-5">
+            submit
+          </button>
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</div>

--- a/vendor/nodebb-theme-harmony-2.1.15/templates/voice.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/voice.tpl
@@ -1,0 +1,30 @@
+<div class="container my-5">
+  <div class="row justify-content-center">
+    <div class="col-12 col-md-8 col-lg-6 text-center">
+
+      <h2 class="mb-3">Voice Channel - {role}</h2>
+
+      <p class="mb-5 fs-5">{queueCount} students ahead of you</p>
+
+      <form method="post" action="{config.relative_path}/voice/submit">
+
+        <div class="mb-4">
+          <label for="voice-question" class="visually-hidden">Your question</label>
+          <textarea id="voice-question"
+                    name="question"
+                    class="form-control form-control-lg text-center py-4"
+                    rows="3"
+                    placeholder="Please enter your question"></textarea>
+        </div>
+
+        <div>
+          <button type="submit" class="btn btn-secondary btn-lg px-5">
+            submit
+          </button>
+        </div>
+
+      </form>
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Milestone Progress:
- Our milestone was initally aimed at creating the user stories voice channel and pinned threads - however, we faced some unexpected roadblocks: the voice channel user story was unexpectedly hard to implement and we had to shift gears to focus on another user story from our original list. For now, voice channel is placed into the backlog and we've discussed to scale back on the functionalities for this feature. Instead, we've implemented anonymous posts for the first sprint. The voice UI will be a work in progress / abandoned until we decide otherwise.

**Summary**
Creates a basic (dummy) OH queue student interface that displays the voice channel queue for any user - ideally it would be it should be implemented with basic voice channel functionalities in order to function.

**Changes**
- added paths the sidebar tpl file to redirect the page to switch to the voice channel tpl when clicked
- added icons for most buttons
- added a voice.tpl file (contains the basic queue information, a text entry box, and a submit button)

**Testing** 
- verfied with npm test 
- lint tests passed: 
- Linting: npm run lint returns clean (after formatting fixes).
- structure of the UI is visually apparent
<img width="2369" height="1408" alt="image" src="https://github.com/user-attachments/assets/9d5b90f9-1681-434a-9513-bcc0e7f1a065" />

**Why**
Establishes the foundational UI so we can integrate real voice/OH logic later without blocking on design or routing.